### PR TITLE
document auth property in webhooks section of processing chain

### DIFF
--- a/src/actinia_core/models/process_chain.py
+++ b/src/actinia_core/models/process_chain.py
@@ -466,6 +466,11 @@ class Webhooks(Schema):
     """
     type = 'object'
     properties = {
+        'auth': {'type': 'string',
+                 'description': 'Authentication information (username and password) '
+					            'to authenticate to the webhook url.Given as '
+					            '"username:password" string. The username and '
+					            'password should not contain a ":".'},
         'update': {'type': 'string',
                    'description': 'Specify a HTTP(S) GET/POST endpoint that should be '
                                   'called when a status update is available while the '
@@ -496,6 +501,7 @@ class Webhooks(Schema):
         'will be used to check if the webhooks endpoints are available.'
         'The finished endpoint is mandatory, the update endpoint is optional.')
     example = {
+        'auth': 'username:password',
         'update': f'http://business-logic.company.com{URL_PREFIX}/'
                   'actinia-update-webhook',
         'finished': f'http://business-logic.company.com{URL_PREFIX}/'
@@ -617,6 +623,7 @@ class ProcessChainModel(Schema):
         }
         ],
         'webhooks': {
+            'auth': 'username:password',
             'update': f'http://business-logic.company.com{URL_PREFIX}/'
                       'actinia-update-webhook',
             'finished': f'http://business-logic.company.com{URL_PREFIX}/'


### PR DESCRIPTION
This PR is an attempt to document the `auth` property in the `webhooks` section of a processing chain. Currently, this is not visible in swagger.json / ReDoc.
I have not tested it and I am not sure this is the right way to add to the documentaion...

It would be good it `auth` would support _base64_ encoded strings (instead of username and password in plain text), or even better, if actinia had secrets management (like e.g. in github actions, see also: #398).