### PR TITLE
Allow one job queue per user

### DIFF
--- a/redis_queue.md
+++ b/redis_queue.md
@@ -20,7 +20,14 @@ queue_type = redis
 `cd ~/repos/actinia` + press F5
 - Start Container for worker
 ```
-docker-compose -f actinia-docker/docker-compose-dev-rq.yml run --rm --service-ports --entrypoint sh actinia-worker
+MY_ACTINIA_DATA=$HOME/actinia
+docker run --rm -it --entrypoint sh \
+    -v $HOME/repos/actinia/actinia-docker/actinia-dev/actinia.cfg:/etc/default/actinia \
+    -v $MY_ACTINIA_DATA/workspace:/actinia_core/workspace \
+    -v $MY_ACTINIA_DATA/resources:/actinia_core/resources \
+    -v $MY_ACTINIA_DATA/grassdb:/actinia_core/grassdb \
+    -v $MY_ACTINIA_DATA/grassdb_user:/actinia_core/userdata \
+    --network actinia-docker_actinia-dev mundialis/actinia:2.5.6
 ```
 - inside container, start worker listening to specified queue
 ```

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -384,7 +384,8 @@ class Configuration(object):
         # It will be extended by a numerical suffix that represents
         # the worker id/number database to re-queue it, usually this is not
         # necessary. If QUEUE_TYPE = per_job, it is extended by the
-        # resource_id of the job.
+        # resource_id of the job, if QUEUE_TYPE = per_user, it is extended
+        # by the user_id
         self.WORKER_QUEUE_PREFIX = "job_queue"
         # Type of queue.
         # "local":  Single queue for all jobs, processed by same actinia
@@ -396,8 +397,11 @@ class Configuration(object):
         #           is ignored. Processed by different actinia instance
         #           (actinia worker). Resource_id will be added to above
         #           WORKER_QUEUE_PREFIX.
+        # "per_user": Separate queue for each user, config for NUMBER_OF_WORKERS
+        #           is ignored. Processed by different actinia instance
+        #           (actinia worker). User_id will be added to above
+        #           WORKER_QUEUE_PREFIX.
         # future ideas
-        # - redis separate queue per user
         # - redis separate queue per process type
         # - redis separate queue per resource consumption
         self.QUEUE_TYPE = "local"

--- a/src/actinia_core/rest/base/resource_base.py
+++ b/src/actinia_core/rest/base/resource_base.py
@@ -132,6 +132,11 @@ class ResourceBase(Resource):
                 global_config.WORKER_QUEUE_PREFIX,
                 self.resource_id,
             )
+        elif global_config.QUEUE_TYPE == "per_user":
+            self.queue = "%s_%s" % (
+                global_config.WORKER_QUEUE_PREFIX,
+                self.user_id,
+        )
         elif global_config.QUEUE_TYPE == "redis":
             self.queue = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, "count")
         else:

--- a/src/actinia_core/rest/base/resource_base.py
+++ b/src/actinia_core/rest/base/resource_base.py
@@ -136,7 +136,7 @@ class ResourceBase(Resource):
             self.queue = "%s_%s" % (
                 global_config.WORKER_QUEUE_PREFIX,
                 self.user_id,
-        )
+            )
         elif global_config.QUEUE_TYPE == "redis":
             self.queue = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, "count")
         else:


### PR DESCRIPTION
This PR allows to specify a separate queue for each user, user_id included in queue name. See also https://github.com/actinia-org/actinia-core/pull/355

When a request is made which writes a job in the queue, actinia logs the following:
```
[2023-04-27 10:31:39,944] INFO      : actinia-core.redis_interface -Create queue job_queue_lina with server redis-queue:6379 [in /src/actinia_core/src/actinia_core/core/common/redis_interface.py:91]
[2023-04-27 10:31:39,945] INFO      : actinia-core.redis_interface -Enqueue job in queue job_queue_lina [in /src/actinia_core/src/actinia_core/core/common/redis_interface.py:113]
```
Then the actinia-worker can be started with:
```
rq_custom_worker job_queue_lina -c /etc/default/actinia --quit
```
Co-authored-by: @linakrisztian 