### PR TITLE
docker CI: only run CI in actinia-org remote

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
   # take care of latest tag
   docker-main-latest:
     name: build and push latest for main branch
-    if: startsWith(github.ref, 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/heads/main') && github.repository_owner == 'actinia-org'
     runs-on: ubuntu-latest
 
     steps:
@@ -69,7 +69,7 @@ jobs:
   # On release, take care of latest and release tags
   docker-sha-release-latest:
     name: build and push release or latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'actinia-org'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Avoid docker CI runs in forks as being useless and a waste of CPU power/energy.