### PR TITLE
Allow redis queue config to be overwritten by env vars

### DIFF
--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -1037,11 +1037,15 @@ class Configuration(object):
 
         if os.environ.get("REDIS_QUEUE_SERVER_PORT"):
             print_warning("QUEUE", "REDIS_QUEUE_SERVER_PORT")
-            self.REDIS_QUEUE_SERVER_PORT = os.environ["REDIS_QUEUE_SERVER_PORT"]
+            self.REDIS_QUEUE_SERVER_PORT = os.environ[
+                "REDIS_QUEUE_SERVER_PORT"
+            ]
 
         if os.environ.get("REDIS_QUEUE_SERVER_PW"):
             print_warning("QUEUE", "REDIS_QUEUE_SERVER_PASSWORD", "XXX", "XXX")
-            self.REDIS_QUEUE_SERVER_PASSWORD = os.environ["REDIS_QUEUE_SERVER_PW"]
+            self.REDIS_QUEUE_SERVER_PASSWORD = os.environ[
+                "REDIS_QUEUE_SERVER_PW"
+            ]
 
 
 global_config = Configuration()

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -1030,7 +1030,7 @@ class Configuration(object):
         if os.environ.get("REDIS_SERVER_PW"):
             print_warning("REDIS", "REDIS_SERVER_PW", "XXX", "XXX")
             self.REDIS_SERVER_PW = os.environ["REDIS_SERVER_PW"]
-            
+
         if os.environ.get("REDIS_QUEUE_SERVER_URL"):
             print_warning("QUEUE", "REDIS_QUEUE_SERVER_URL")
             self.REDIS_QUEUE_SERVER_URL = os.environ["REDIS_QUEUE_SERVER_URL"]
@@ -1040,7 +1040,7 @@ class Configuration(object):
             self.REDIS_QUEUE_SERVER_PORT = os.environ["REDIS_QUEUE_SERVER_PORT"]
 
         if os.environ.get("REDIS_QUEUE_SERVER_PW"):
-            print_warning("QUEUE", "REDIS_QUEUE_SERVER_PW", "XXX", "XXX")
+            print_warning("QUEUE", "REDIS_QUEUE_SERVER_PASSWORD", "XXX", "XXX")
             self.REDIS_QUEUE_SERVER_PASSWORD = os.environ["REDIS_QUEUE_SERVER_PW"]
 
 

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -1030,6 +1030,18 @@ class Configuration(object):
         if os.environ.get("REDIS_SERVER_PW"):
             print_warning("REDIS", "REDIS_SERVER_PW", "XXX", "XXX")
             self.REDIS_SERVER_PW = os.environ["REDIS_SERVER_PW"]
+            
+        if os.environ.get("REDIS_QUEUE_SERVER_URL"):
+            print_warning("QUEUE", "REDIS_QUEUE_SERVER_URL")
+            self.REDIS_QUEUE_SERVER_URL = os.environ["REDIS_QUEUE_SERVER_URL"]
+
+        if os.environ.get("REDIS_QUEUE_SERVER_PORT"):
+            print_warning("QUEUE", "REDIS_QUEUE_SERVER_PORT")
+            self.REDIS_QUEUE_SERVER_PORT = os.environ["REDIS_QUEUE_SERVER_PORT"]
+
+        if os.environ.get("REDIS_QUEUE_SERVER_PW"):
+            print_warning("QUEUE", "REDIS_QUEUE_SERVER_PW", "XXX", "XXX")
+            self.REDIS_QUEUE_SERVER_PASSWORD = os.environ["REDIS_QUEUE_SERVER_PW"]
 
 
 global_config = Configuration()


### PR DESCRIPTION
This PR allows to set the configuration for redis queue database connection parameters via environment variables.
The same was already possible for the other redis database connection configuration containing resources etc.