### PR TITLE
Increase allowed length of additional version info key

### DIFF
--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -91,7 +91,7 @@ def valid_additional_version_info_key(cand):
     a length between 1 and 20 and must not be any of the reserved keys which
     we will set and populate."""
     minlength = 1
-    maxlength = 20
+    maxlength = 25
     valid_reg_ex = "^[a-z_]{" + str(minlength) + "," + str(maxlength) + "}$"
     reserved_keys = [
         "grass_version",


### PR DESCRIPTION
To allow information for `actinia_docker_version` which has 22 characters, it is necessary to allow more than 20 chars.