### PR TITLE
Change runtime if runtime is higher 2147483647

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ To lint your local changes, run
     ```
     pip3 uninstall actinia_core
     cd /src/actinia_core && pip3 install .
-    rq_custom_worker job_queue_0 -c /etc/default/actinia
+    actinia-worker job_queue_0 -c /etc/default/actinia
     ```
 
 ## Local dev-setup with configured endpoints

--- a/redis_queue.md
+++ b/redis_queue.md
@@ -32,7 +32,7 @@ docker run --rm -it --entrypoint sh \
 - inside container, start worker listening to specified queue
 ```
 QUEUE_NAME=job_queue_0
-rq_custom_worker $QUEUE_NAME -c /etc/default/actinia --quit
+actinia-worker $QUEUE_NAME -c /etc/default/actinia --quit
 ```
 
 

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -103,14 +103,16 @@ def __enqueue_job_redis(queue, timeout, func, *args):
     """
 
     log.info("Enqueue job in queue %s" % queue.name)
-    # Below timeout is defined in resource_base.pyL295:
+    # Below timeout is defined in resource_base.pyL295 will be changed because:
     # int(process_time_limit * process_num_limit * 20)
     # which is 630720000000 and raises in worker:
     # OverflowError: Python int too large to convert to C int
+    if timeout > 2147483647:
+        timeout = -1  # never exprire
     ret = queue.enqueue(
         func,
         *args,
-        # job_timeout=timeout,
+        job_timeout=timeout,
         ttl=global_config.REDIS_QUEUE_JOB_TTL,
         result_ttl=global_config.REDIS_QUEUE_JOB_TTL
     )


### PR DESCRIPTION
In the worker the allowed `job_timeout` of an user is not allowed to be higher than 2147483647.
For this the `job_timeout` is set to `-1` which means never expire if the user has a timout higher.