### PR TITLE
Fixes currently failing test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ install:
 	pip3 install .
 
 test:
-	./tests_with_redis.sh
+	sh ./tests_with_redis.sh
 
 unittest:
 	pytest -m unittest
 
 devtest:
-	./tests_with_redis.sh dev
+	sh ./tests_with_redis.sh dev
 
 integrationtest:
-	./tests_with_redis.sh integrationtest
+	sh ./tests_with_redis.sh integrationtest

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -41,8 +41,6 @@ RUN grass --tmp-location EPSG:4326 --exec g.extension -s \
 COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia
 COPY docker/actinia-core-tests/actinia-test.cfg /etc/default/actinia_test
 
-COPY requirements.txt /src/requirements.txt
-RUN pip3 install -r /src/requirements.txt
 RUN pip3 install pytest pytest-cov
 
 # TODO: Postgres for tests
@@ -50,7 +48,6 @@ RUN pip3 install pytest pytest-cov
 
 COPY . /src/actinia_core
 WORKDIR /src/actinia_core
-RUN chmod a+x tests_with_redis.sh
 
 RUN make install
 

--- a/src/actinia_core/cli/webhook_server.py
+++ b/src/actinia_core/cli/webhook_server.py
@@ -49,9 +49,9 @@ def finished():
         pprint(json.loads(request.get_json()))
     except BadRequest:
         pass
-    except TypeError:
-        pass
     except UnsupportedMediaType:
+        pass
+    except TypeError:
         pass
     return make_response(jsonify("OK"), 200)
 
@@ -62,9 +62,9 @@ def update():
         pprint(json.loads(request.get_json()))
     except BadRequest:
         pass
-    except TypeError:
-        pass
     except UnsupportedMediaType:
+        pass
+    except TypeError:
         pass
     return make_response(jsonify("OK"), 200)
 

--- a/src/actinia_core/cli/webhook_server.py
+++ b/src/actinia_core/cli/webhook_server.py
@@ -29,7 +29,7 @@ import argparse
 import psutil
 from flask import Flask, make_response, jsonify, request, json
 from multiprocessing import Process
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, UnsupportedMediaType
 
 from pprint import pprint
 
@@ -44,11 +44,14 @@ flask_app = Flask(__name__)
 
 @flask_app.route("/webhook/finished", methods=["GET", "POST"])
 def finished():
+
     try:
         pprint(json.loads(request.get_json()))
     except BadRequest:
         pass
     except TypeError:
+        pass
+    except UnsupportedMediaType:
         pass
     return make_response(jsonify("OK"), 200)
 
@@ -60,6 +63,8 @@ def update():
     except BadRequest:
         pass
     except TypeError:
+        pass
+    except UnsupportedMediaType:
         pass
     return make_response(jsonify("OK"), 200)
 

--- a/src/actinia_core/cli/webhook_server_broken.py
+++ b/src/actinia_core/cli/webhook_server_broken.py
@@ -29,7 +29,7 @@ import argparse
 import psutil
 from flask import Flask, make_response, jsonify, request, json
 from multiprocessing import Process
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, UnsupportedMediaType
 
 from pprint import pprint
 
@@ -51,6 +51,8 @@ def finished():
         pass
     except TypeError:
         pass
+    except UnsupportedMediaType:
+        pass
     sp = Process(target=shutdown_server, args=(port,))
     sp.start()
     return make_response(jsonify("Server shutting down..."), 200)
@@ -63,6 +65,8 @@ def update():
     except BadRequest:
         pass
     except TypeError:
+        pass
+    except UnsupportedMediaType:
         pass
     return make_response(jsonify("OK"), 200)
 

--- a/src/actinia_core/cli/webhook_server_broken.py
+++ b/src/actinia_core/cli/webhook_server_broken.py
@@ -49,9 +49,9 @@ def finished():
         pprint(json.loads(request.get_json()))
     except BadRequest:
         pass
-    except TypeError:
-        pass
     except UnsupportedMediaType:
+        pass
+    except TypeError:
         pass
     sp = Process(target=shutdown_server, args=(port,))
     sp.start()
@@ -64,9 +64,9 @@ def update():
         pprint(json.loads(request.get_json()))
     except BadRequest:
         pass
-    except TypeError:
-        pass
     except UnsupportedMediaType:
+        pass
+    except TypeError:
         pass
     return make_response(jsonify("OK"), 200)
 


### PR DESCRIPTION
This PR
- fixes `test_async_processing_new` by catching an additional exception of werkzeug
- Calls `./tests_with_redis.sh` via `sh` to not depend on `chmod` to have local test setup clean
- do not use `requirements.txt` anymore but install dependencies from `pyproject.toml`