### PR TITLE
Make resource storage delete asynchron

### DIFF
--- a/src/actinia_core/rest/resource_storage_management.py
+++ b/src/actinia_core/rest/resource_storage_management.py
@@ -129,7 +129,7 @@ class SyncResourceStorageResource(ResourceBase):
                 olderthan,
                 queue_type_overwrite=True,
             )
-            http_code, response_model = self.wait_until_finish()
+            http_code, response_model = pickle.loads(self.response_data)
         else:
             http_code, response_model = pickle.loads(self.response_data)
 


### PR DESCRIPTION
Make resource storage delete asynchron because of timeout when the resource storage has a large amount of data.