### PR TITLE
Reset test markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,7 @@ addopts = "--cov actinia_core --cov-report term-missing --verbose --tb=line -x"
 testpaths = [
     "tests",
 ]
+markers = [
+    "dev: test current in development",
+    "unittest: completely independent test",
+]


### PR DESCRIPTION
You can execute only unittests or dev tests without registering the markers, but e.g. for listing all markers you have to register them:
```
pytest --markers
@pytest.mark.dev: test current in development
@pytest.mark.unittest: completely independent test
....
```
see also https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers