### PR TITLE
Enable import via vsicurl

### DIFF
--- a/src/actinia_core/core/common/process_chain.py
+++ b/src/actinia_core/core/common/process_chain.py
@@ -441,20 +441,28 @@ class ProcessChainConverter(object):
         """
         rvf_downimport_commands = list()
         url = entry["import_descr"]["source"]
-        gdis = GeoDataDownloadImportSupport(
-            config=self.config,
-            temp_file_path=self.temp_file_path,
-            download_cache=self.temp_file_path,
-            message_logger=self.message_logger,
-            send_resource_update=self.send_resource_update,
-            url_list=[
-                url,
-            ],
-        )
-        download_commands, import_file_info = gdis.get_download_process_list()
-        rvf_downimport_commands.extend(download_commands)
+
+        if not url.startswith("/vsicurl/"):
+            gdis = GeoDataDownloadImportSupport(
+                config=self.config,
+                temp_file_path=self.temp_file_path,
+                download_cache=self.temp_file_path,
+                message_logger=self.message_logger,
+                send_resource_update=self.send_resource_update,
+                url_list=[
+                    url,
+                ],
+            )
+            (
+                download_commands,
+                import_file_info,
+            ) = gdis.get_download_process_list()
+            rvf_downimport_commands.extend(download_commands)
+            input_source = import_file_info[0][2]
+        else:
+            input_source = url
+
         map_name = entry["value"]
-        input_source = import_file_info[0][2]
         layer = None
 
         if "vector_layer" in entry["import_descr"]:

--- a/src/actinia_core/core/geodata_download_importer.py
+++ b/src/actinia_core/core/geodata_download_importer.py
@@ -140,6 +140,8 @@ class GeoDataDownloadImportSupport(object):
         nothing needs to be downloaded and checked.
         """
         for url in self.url_list:
+            if url.startswith("/vsicurl/"):
+                continue
             # Send a resource update
             if self.send_resource_update is not None:
                 self.send_resource_update(


### PR DESCRIPTION
This PR enables the user to import online raster resources via vsicurl via importer. In comparison to the current raster import it skips the `wget` step and passes the URL directly to `r.import`.
The vsicurl URL can directly be specified in the process chain:
```
    {
      "id": "importer_1",
      "module": "importer",
      "inputs": [
        {
          "import_descr": {
            "source": "/vsicurl/https://github.com/giswqs/data/raw/main/raster/srtm90.tif",
            "type": "raster",
            "resample": "bilinear_f",
            "resolution": "value",
            "resolution_value": "100"
          },
          "param": "map",
          "value": "mangkawuk_srtmgl1_v003_30m"
        }
      ]
    },
```

Output before without vsicurl URL:
```
"process_log": [
    {
      "executable": "/usr/bin/wget",
      "id": "importer_wget_myraster.tiff",
      "mapset_size": 421,
      "parameter": [
        "-t5",
        "-c",
        "-q",
        "-O",
        "/actinia_core/workspace/temp_db/gisdbase_aab038cc892a4eb199b3e3251ea51b9a/.tmp/myraster.tiff",
        "https://raw.githubusercontent.com/mmacata/pagestest/gh-pages/myraster.tiff"
      ],
      "return_code": 0,
      "run_time": 4.188900709152222,
      "stderr": [
        ""
      ],
      "stdout": ""
    },
    {
      "executable": "r.import",
      "id": "r_import_myraster.tiff",
      "mapset_size": 421,
      "parameter": [
        "input=/actinia_core/workspace/temp_db/gisdbase_aab038cc892a4eb199b3e3251ea51b9a/.tmp/myraster.tiff",
        "output=myraster",
        "--q",
        "resample=bilinear_f",
        "resolution=value",
        "resolution_value=100"
      ],
      "return_code": 1,
      "run_time": 1.5571587085723877,
      "stderr": [
        "WARNING: Invalid east longitude -246.534",
        "WARNING: Unable to determine area of interest for '+proj=lcc +lat_1=36.16666666666666 +lat_2=34.33333333333334 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +no_defs +a=6378137 +rf=298.257222101 +towgs84=0.000,0.000,0.000 +type=crs '",
        "ERROR: Unable to initialize coordinate transformation",
        "ERROR: Unable to reproject to source location",
        ""
      ],
      "stdout": ""
    }
  ],
```
This is still possible. But now with vsicurl:
```
"process_log": [
    {
      "executable": "r.import",
      "id": "r_import_myraster.tif",
      "mapset_size": 24187896,
      "parameter": [
        "input=/vsicurl/https://github.com/giswqs/data/raw/main/raster/srtm90.tif",
        "output=myraster",
        "--q",
        "resample=bilinear_f",
        "resolution=value",
        "resolution_value=100"
      ],
      "return_code": 0,
      "run_time": 45.551167488098145,
      "stderr": [
        ""
      ],
      "stdout": ""
    }
  ],
```

These changes were tested with superadmin and normal user. The users limits were decreased to show the effect. For only 1 allowed pixel, v.import runs through but then the next step fails with `"message": "AsyncProcessError:  Region too large, set a coarser resolution to minimum nsres: 343448.918425 ewres: 343448.918425 [num_cells: 11781980]",`. This might be critical as a large image could do harm to a running actinia installation? What do you think @anikaweinmann @neteler ?
With only one second allowed for calculation, actinia behaves as it should: `"message": "AsyncProcessTimeLimit:  Time (1 seconds) exceeded to run executable r.import",`.


