### PR TITLE
Fix import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
     "osgeo",
 ]
 dependencies = [
-    "actinia-api==3.4.0",
+    "actinia-api==3.4.1",
     "Flask>=3.0.0",
     "boto3>=1.6.6",
     "colorlog>=4.2.1",

--- a/src/actinia_core/__init__.py
+++ b/src/actinia_core/__init__.py
@@ -21,11 +21,10 @@
 #
 #######
 
-from pkg_resources import get_distribution, DistributionNotFound
-
+import importlib.metadata
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(dist_name)
+except Exception:
     __version__ = "unknown"


### PR DESCRIPTION
After upgrade to alpine 3.20 including update to python 3.12, the following error appeared:

`AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?`

This PR suggests to use a more modern approach while still allowing use of older versions.

See also https://github.com/actinia-org/actinia-api/pull/25
