### PR TITLE
Updates for g84 and python

### DIFF
--- a/src/actinia_core/core/interim_results.py
+++ b/src/actinia_core/core/interim_results.py
@@ -186,7 +186,7 @@ class InterimResult(object):
         # get sha512sum of the folder
         cur_working_dir = os.getcwd()
         sha512sum_cmd = (
-            "find . -type f -exec sha512sum {} \; | " + "sort -k 2 | sha512sum"
+            r"find . -type f -exec sha512sum {} \; | " + "sort -k 2 | sha512sum"
         )
         sha512sums = list()
         for folder in [folder1, folder2]:

--- a/src/actinia_core/models/process_chain.py
+++ b/src/actinia_core/models/process_chain.py
@@ -122,7 +122,7 @@ class InputParameter(IOParameterBase):
                 " raster map layers have a specific name scheme, that "
                 "is independent from the provided map name in the "
                 "process description. The name scheme is always: "
-                "<p>\<landsat scene id\>_\<atcor\>.\<band\></p>"
+                r"<p>\<landsat scene id\>_\<atcor\>.\<band\></p>"
                 "For example, if the scene <p>LT52170762005240COA00</p> "
                 "was requested, the resulting name for the DOS1 "
                 "atmospheric corrected band 1 would be: "

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -34,9 +34,9 @@ __copyright__ = (
 __maintainer__ = "mundialis"
 
 from flask import make_response, jsonify, request
+from importlib import metadata
 import os
 import re
-import importlib
 import subprocess
 import sys
 from actinia_api import URL_PREFIX
@@ -71,16 +71,20 @@ def init_versions():
     ).stdout
     log.debug("Detecting GRASS GIS version")
     for i in g_version.decode("utf-8").strip("\n").split("\n"):
-        G_VERSION[i.split("=")[0]] = i.split("=")[1]
+        try:
+            G_VERSION[i.split("=")[0]] = i.split("=")[1]
+        except IndexError:
+            pass
 
     log.debug("Detecting Plugin versions")
     for i in global_config.PLUGINS:
-        module = importlib.import_module(i)
-        PLUGIN_VERSIONS[i] = module.__version__
+        try:
+            PLUGIN_VERSIONS[i] = metadata.version(i)
+        except metadata.PackageNotFoundError:
+            PLUGIN_VERSIONS[i] = metadata.version(f"{i}.wsgi")
 
     log.debug("Detecting API versions")
-    module = importlib.import_module("actinia_api")
-    API_VERSION = module.__version__
+    API_VERSION = metadata.version("actinia_api")
 
     PYTHON_VERSION = sys.version.replace("\n", "- ")
 


### PR DESCRIPTION
This PR suggests some updates for upcoming GRASS GIS 8.4 and more recent python versions (remove deprecation warnings and prepare actinia plugins for update).