### PR TITLE
Ignore local linting config for pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ docker/redis_queue_data/dump.rdb
 !docker/actinia-core-dev/actinia.cfg
 !docker/actinia-core-dev/endpoints.csv
 !docker/actinia-core-tests/*.cfg
+
+# linting with shared config file
+ruff-github-workflows.toml
+ruff-merged.toml

--- a/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
+++ b/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
@@ -1367,7 +1367,7 @@ class EphemeralProcessing(object):
         if self.skip_region_check is True:
             return
 
-        errorid, stdout_buff, _ = self.ginit.run_module("g.region", ["-ug"])
+        errorid, stdout_buff, dummy = self.ginit.run_module("g.region", ["-ug"])
 
         if errorid != 0:
             raise AsyncProcessError(

--- a/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
+++ b/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
@@ -1367,7 +1367,7 @@ class EphemeralProcessing(object):
         if self.skip_region_check is True:
             return
 
-        errorid, stdout_buff, dummy = self.ginit.run_module("g.region", ["-ug"])
+        errorid, stdout_buff, _ = self.ginit.run_module("g.region", ["-ug"])
 
         if errorid != 0:
             raise AsyncProcessError(


### PR DESCRIPTION
As pre-commit config for ruff is based on the [shared workflows](https://github.com/mundialis/github-workflows/blob/main/pre_commit_hooks/linting.sh#L194-L198) which will be merged with the one from this repo, these files shouldn't be commited.