### PR TITLE
Fix g.remove error msg check

### DIFF
--- a/src/actinia_core/processing/actinia_processing/persistent/map_layer_management.py
+++ b/src/actinia_core/processing/actinia_processing/persistent/map_layer_management.py
@@ -120,8 +120,13 @@ class PersistentRemoveLayers(PersistentProcessing):
 
         self._execute_process_list(process_list)
 
-        if "WARNING: No data base element files found" in "\n".join(
-            self.module_output_log[0]["stderr"]
+        # TODO: check for error code if g.remove is updated
+        # instead of using string which might change
+        # self.module_output_log[0]["return_code"] != 0
+        error_output = "\n".join(self.module_output_log[0]["stderr"])
+        if (
+            "WARNING: No data base element files found" in error_output
+            or "No file(s) found for type(s)" in error_output
         ):
             raise AsyncProcessError("<%s> layer not found" % layer_type)
 

--- a/src/actinia_core/processing/actinia_processing/persistent/raster_layer.py
+++ b/src/actinia_core/processing/actinia_processing/persistent/raster_layer.py
@@ -73,8 +73,13 @@ class PersistentRasterDeleter(PersistentProcessing):
 
         self._execute_process_list(process_list)
 
-        if "WARNING: No data base element files found" in "\n".join(
-            self.module_output_log[0]["stderr"]
+        # TODO: check for error code if g.remove is updated
+        # instead of using string which might change
+        # self.module_output_log[0]["return_code"] != 0
+        error_output = "\n".join(self.module_output_log[0]["stderr"])
+        if (
+            "WARNING: No data base element files found" in error_output
+            or "No file(s) found for type(s)" in error_output
         ):
             raise AsyncProcessError(
                 "Raster layer <%s> not found" % raster_name

--- a/src/actinia_core/processing/actinia_processing/persistent/vector_layer.py
+++ b/src/actinia_core/processing/actinia_processing/persistent/vector_layer.py
@@ -74,8 +74,13 @@ class PersistentVectorDeleter(PersistentProcessing):
 
         self._execute_process_list(process_list)
 
-        if "WARNING: No data base element files found" in "\n".join(
-            self.module_output_log[0]["stderr"]
+        # TODO: check for error code if g.remove is updated
+        # instead of using string which might change
+        # self.module_output_log[0]["return_code"] != 0
+        error_output = "\n".join(self.module_output_log[0]["stderr"])
+        if (
+            "WARNING: No data base element files found" in error_output
+            or "No file(s) found for type(s)" in error_output
         ):
             raise AsyncProcessError(
                 "Vector layer <%s> not found" % (vector_name)


### PR DESCRIPTION
After update of the error message from `g.remove` https://github.com/OSGeo/grass/pull/5484 actinia returns HTTP code 200 instead of 400 when trying to remove a layer which doesn't exist.
This PR parses the new error message of `g.remove` while staying backwards-compatibility.