### PR TITLE
docker/actinia-core-alpine/start.sh: fix missing --text in grass call

### DIFF
--- a/docker/actinia-core-alpine/start.sh
+++ b/docker/actinia-core-alpine/start.sh
@@ -8,7 +8,7 @@ mkdir -p /actinia_core/workspace/tmp
 mkdir -p /actinia_core/resources
 
 # Create default project in mounted (!) directory
-[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass --text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi
@@ -18,8 +18,8 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
-# optimized gunicorn settings (http://docs.gunicorn.org/en/stable/design.html) # run only 1 worker for debugging reasons. This is overwritten for production
-# deployment.
+# optimized gunicorn settings (http://docs.gunicorn.org/en/stable/design.html)
+# run only 1 worker for debugging reasons. This is overwritten for production  deployment.
 gunicorn -b 0.0.0.0:8088 -w 8 --access-logfile=- -k gthread actinia_core.main:flask_app
 status=$?
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
- fix missing `--text` in `grass` call (reported by @LorenzoBottaccioli)
- comment line break cosmetics