### PR TITLE
Update Sentinel-2 download datasource and id parameter

### DIFF
--- a/src/actinia_core/core/common/sentinel_processing_library.py
+++ b/src/actinia_core/core/common/sentinel_processing_library.py
@@ -423,8 +423,8 @@ class Sentinel2Processing(object):
             exec_type="grass",
             executable="i.sentinel.download",
             executable_params=[
-                "datasource=GCS",
-                f"query=identifier={self.product_id}",
+                "datasource=ESA_CDSE",
+                f"id={self.product_id}",
                 f"output={self.user_download_cache_path}",
             ],
             id=f"i_sentinel_download_{self.product_id}",

--- a/tests/unittests/test_sentinel2_processing_commands.py
+++ b/tests/unittests/test_sentinel2_processing_commands.py
@@ -127,9 +127,9 @@ class Sentinel2ProcessingLibraryTestCase(unittest.TestCase):
             ("Download process executable is not " "i.sentinel.download"),
         )
         ref_params = [
-            "datasource=GCS",
+            "datasource=ESA_CDSE",
             (
-                "query=identifier=S2A_MSIL1C_20170212T104141"
+                "id=S2A_MSIL1C_20170212T104141"
                 "_N0204_R008_T31TGJ_20170212T104138"
             ),
             "output=/tmp",


### PR DESCRIPTION
This PR updates the Sentinel-2 download command to use the ESA Copernicus Data Space Ecosystem instead of the deprecated Google Cloud Storage datasource. Products are now selected using the `id` option supported by the current version of `i.sentinel.download`.
Fixes #261  