### PR TITLE
Update alpine dependencies image tag

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2019-2025 by mundialis GmbH & Co. KG
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM mundialis/actinia:alpine-dependencies-2026-07-14 AS build-base
+FROM mundialis/actinia:alpine-dependencies-2026-09-08 AS build-base
 FROM osgeo/grass-gis:main-alpine AS grass
 
 FROM build-base AS requirements


### PR DESCRIPTION
Updates the alpine-dependencies image from 2026-07-14 to 2026-09-08.

The new image was tested locally with a full actinia-core build. The build completed successfully, and a Grype scan no longer reports vulnerabilities for pillow, fonttools, aiohttp, tornado, or msgpack.